### PR TITLE
Add script to generate scaled PNG flags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+dist/png/
 node_modules/
 .vercel

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "homepage": "https://github.com/RudeySH/flags#readme",
   "dependencies": {
-    "jsdom": "^20.0.0"
+    "jsdom": "^20.0.0",
+    "sharp": "^0.31.0"
   }
 }

--- a/scripts/generateScaledPNG.mjs
+++ b/scripts/generateScaledPNG.mjs
@@ -1,0 +1,51 @@
+import fs from "fs/promises";
+import path from "path";
+import sharp from "sharp";
+
+// TODO: pass these in as CLI arguments
+const BACKGROUND = "#0000";
+const SCALING_KERNEL = undefined;
+const SIZES_TO_GENERATE = [
+  // each object must have a width or a height or both(contain)
+  // can pass kernel property as well to control scaling algorithm
+  { height: 24 },
+];
+
+async function scaleFlag(metaInfo, options) {
+  const svgPath = path.join("svg", `${metaInfo.route}.svg`);
+
+  if (!options.width && !options.height) {
+    throw new Error("either width, height or both must be specified");
+  }
+
+  const result = await sharp(svgPath)
+    .resize(options.width, options.height, {
+      fit: "contain",
+      background: BACKGROUND,
+      kernel: options.kernel || SCALING_KERNEL,
+    })
+    .png()
+    .toBuffer({ resolveWithObject: true });
+
+  const pngPath = path.join(
+    "dist",
+    "png",
+    `${result.info.width}x${result.info.height}`,
+    `${metaInfo.route}.png`
+  );
+
+  await fs.mkdir(path.dirname(pngPath), { recursive: true });
+  await fs.writeFile(pngPath, result.data);
+}
+
+(async () => {
+  const metaContents = await fs.readFile("dist/metadata.json", "utf-8");
+  const metaData = JSON.parse(metaContents);
+
+  // TODO: show progress message using cli-progress or spinner
+  for (const size of SIZES_TO_GENERATE) {
+    for (const info of metaData) {
+      await scaleFlag(info, size);
+    }
+  }
+})();


### PR DESCRIPTION
I tried hard to KISS in order to make the changes small, even though I had the natural temptation to add more features and improvements.

Future work, intentionally left-out of this PR:

* [ ] Use cli-progress or spinner to give feedback to the user.
* [ ] Use commander or yargs to allow passing hard-coded constants as CLI arguments.
* [ ] Change or allow configuration of the output file paths.
* [ ] Update `dist/metadata.json` to add references to the rendered flags.
* [ ] Add some code that can be used to find the best sized rendered flag or default to SVG.
* [ ] Add `package-lock.json` to `.gitignore` file if it shouldn't be included in the change set.

Closes #7