### PR TITLE
Added flag name metadata for the Netherlands

### DIFF
--- a/svg/nl/aw.svg
+++ b/svg/nl/aw.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="900" height="600" viewBox="0 0 27 18" xmlns:cgf="https://coding.garden/flags"><metadata id="cgf-metadata">
 
 <cgf:flag>
-  <cgf:name></cgf:name>
+  <cgf:name>Aruba</cgf:name>
   <cgf:route>nl/aw</cgf:route>
   <cgf:aspect-ratio>1.5</cgf:aspect-ratio>
 </cgf:flag>

--- a/svg/nl/bq1.svg
+++ b/svg/nl/bq1.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="600" height="400" xmlns:cgf="https://coding.garden/flags"><metadata id="cgf-metadata">
 
 <cgf:flag>
-  <cgf:name></cgf:name>
+  <cgf:name>Bonaire</cgf:name>
   <cgf:route>nl/bq1</cgf:route>
   <cgf:aspect-ratio>1.5</cgf:aspect-ratio>
 </cgf:flag>

--- a/svg/nl/bq2.svg
+++ b/svg/nl/bq2.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="750" height="500" viewBox="-750 -500 1500 1000" xmlns:cgf="https://coding.garden/flags"><metadata id="cgf-metadata">
 
 <cgf:flag>
-  <cgf:name></cgf:name>
+  <cgf:name>Saba</cgf:name>
   <cgf:route>nl/bq2</cgf:route>
   <cgf:aspect-ratio>1.5</cgf:aspect-ratio>
 </cgf:flag>

--- a/svg/nl/bq3.svg
+++ b/svg/nl/bq3.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="900" height="600" xmlns:cgf="https://coding.garden/flags"><metadata id="cgf-metadata">
 
 <cgf:flag>
-  <cgf:name></cgf:name>
+  <cgf:name>Sint Eustatius</cgf:name>
   <cgf:route>nl/bq3</cgf:route>
   <cgf:aspect-ratio>1.5</cgf:aspect-ratio>
 </cgf:flag>

--- a/svg/nl/cw.svg
+++ b/svg/nl/cw.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="900" height="600" viewBox="0 0 54 36" xmlns:cgf="https://coding.garden/flags"><metadata id="cgf-metadata">
 
 <cgf:flag>
-  <cgf:name></cgf:name>
+  <cgf:name>Curaçao</cgf:name>
   <cgf:route>nl/cw</cgf:route>
   <cgf:aspect-ratio>1.5</cgf:aspect-ratio>
 </cgf:flag>

--- a/svg/nl/dr.svg
+++ b/svg/nl/dr.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" version="1" width="750" height="500" xmlns:cgf="https://coding.garden/flags"><metadata id="cgf-metadata">
 
 <cgf:flag>
-  <cgf:name></cgf:name>
+  <cgf:name>Drenthe</cgf:name>
   <cgf:route>nl/dr</cgf:route>
   <cgf:aspect-ratio>1.5</cgf:aspect-ratio>
 </cgf:flag>

--- a/svg/nl/fl.svg
+++ b/svg/nl/fl.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="600" height="400" xmlns:cgf="https://coding.garden/flags"><metadata id="cgf-metadata">
 
 <cgf:flag>
-  <cgf:name></cgf:name>
+  <cgf:name>Flevoland</cgf:name>
   <cgf:route>nl/fl</cgf:route>
   <cgf:aspect-ratio>1.5</cgf:aspect-ratio>
 </cgf:flag>

--- a/svg/nl/fr.svg
+++ b/svg/nl/fr.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="910" height="630" xmlns:cgf="https://coding.garden/flags"><metadata id="cgf-metadata">
 
 <cgf:flag>
-  <cgf:name></cgf:name>
+  <cgf:name>Fryslân</cgf:name>
   <cgf:route>nl/fr</cgf:route>
   <cgf:aspect-ratio>1.4444444444444444</cgf:aspect-ratio>
 </cgf:flag>

--- a/svg/nl/ge.svg
+++ b/svg/nl/ge.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="650" height="450" xmlns:cgf="https://coding.garden/flags"><metadata id="cgf-metadata">
 
 <cgf:flag>
-  <cgf:name></cgf:name>
+  <cgf:name>Gelderland</cgf:name>
   <cgf:route>nl/ge</cgf:route>
   <cgf:aspect-ratio>1.4444444444444444</cgf:aspect-ratio>
 </cgf:flag>

--- a/svg/nl/gr.svg
+++ b/svg/nl/gr.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="600" height="400" xmlns:cgf="https://coding.garden/flags"><metadata id="cgf-metadata">
 
 <cgf:flag>
-  <cgf:name></cgf:name>
+  <cgf:name>Groningen</cgf:name>
   <cgf:route>nl/gr</cgf:route>
   <cgf:aspect-ratio>1.5</cgf:aspect-ratio>
 </cgf:flag>

--- a/svg/nl/li.svg
+++ b/svg/nl/li.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="600" height="400" xmlns:cgf="https://coding.garden/flags"><metadata id="cgf-metadata">
 
 <cgf:flag>
-  <cgf:name></cgf:name>
+  <cgf:name>Limburg</cgf:name>
   <cgf:route>nl/li</cgf:route>
   <cgf:aspect-ratio>1.5</cgf:aspect-ratio>
 </cgf:flag>

--- a/svg/nl/nb.svg
+++ b/svg/nl/nb.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="600" height="400" viewBox="0 0 6 4" xmlns:cgf="https://coding.garden/flags"><metadata id="cgf-metadata">
 
 <cgf:flag>
-  <cgf:name></cgf:name>
+  <cgf:name>Noord-Brabant</cgf:name>
   <cgf:route>nl/nb</cgf:route>
   <cgf:aspect-ratio>1.5</cgf:aspect-ratio>
 </cgf:flag>

--- a/svg/nl/nh.svg
+++ b/svg/nl/nh.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="900" height="600" xmlns:cgf="https://coding.garden/flags"><metadata id="cgf-metadata">
 
 <cgf:flag>
-  <cgf:name></cgf:name>
+  <cgf:name>Noord-Holland</cgf:name>
   <cgf:route>nl/nh</cgf:route>
   <cgf:aspect-ratio>1.5</cgf:aspect-ratio>
 </cgf:flag>

--- a/svg/nl/ov.svg
+++ b/svg/nl/ov.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="750" height="500" viewBox="0 0 60 40" xmlns:cgf="https://coding.garden/flags"><metadata id="cgf-metadata">
 
 <cgf:flag>
-  <cgf:name></cgf:name>
+  <cgf:name>Overijssel</cgf:name>
   <cgf:route>nl/ov</cgf:route>
   <cgf:aspect-ratio>1.5</cgf:aspect-ratio>
 </cgf:flag>

--- a/svg/nl/sx.svg
+++ b/svg/nl/sx.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="675" height="450" xmlns:cgf="https://coding.garden/flags"><metadata id="cgf-metadata">
 
 <cgf:flag>
-  <cgf:name></cgf:name>
+  <cgf:name>Sint Maarten</cgf:name>
   <cgf:route>nl/sx</cgf:route>
   <cgf:aspect-ratio>1.5</cgf:aspect-ratio>
 </cgf:flag>

--- a/svg/nl/ut.svg
+++ b/svg/nl/ut.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="745" height="495" viewBox="0 -2.638 745 495" xmlns:cgf="https://coding.garden/flags"><metadata id="cgf-metadata">
 
 <cgf:flag>
-  <cgf:name></cgf:name>
+  <cgf:name>Utrecht</cgf:name>
   <cgf:route>nl/ut</cgf:route>
   <cgf:aspect-ratio>1.505050505050505</cgf:aspect-ratio>
 </cgf:flag>

--- a/svg/nl/ze.svg
+++ b/svg/nl/ze.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" version="1.0" width="600" height="400" xmlns:cgf="https://coding.garden/flags"><metadata id="cgf-metadata">
 
 <cgf:flag>
-  <cgf:name></cgf:name>
+  <cgf:name>Zeeland</cgf:name>
   <cgf:route>nl/ze</cgf:route>
   <cgf:aspect-ratio>1.5</cgf:aspect-ratio>
 </cgf:flag>

--- a/svg/nl/zh.svg
+++ b/svg/nl/zh.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="336" height="224" xmlns:cgf="https://coding.garden/flags"><metadata id="cgf-metadata">
 
 <cgf:flag>
-  <cgf:name></cgf:name>
+  <cgf:name>Zuid-Holland</cgf:name>
   <cgf:route>nl/zh</cgf:route>
   <cgf:aspect-ratio>1.5</cgf:aspect-ratio>
 </cgf:flag>


### PR DESCRIPTION
Names are Dutch localized. Alternatively, North-Holland would be the English spelling for example, but this commit says Noord-Holland.

Source: https://en.wikipedia.org/wiki/ISO_3166-2:NL